### PR TITLE
Workflow

### DIFF
--- a/Module1-Rust-Data-Structures/exercises/top_words/Cargo.toml
+++ b/Module1-Rust-Data-Structures/exercises/top_words/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "top_words"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/Module1-Rust-Data-Structures/exercises/top_words/Makefile
+++ b/Module1-Rust-Data-Structures/exercises/top_words/Makefile
@@ -1,0 +1,24 @@
+rust-version:
+	@echo "Rust command-line utility versions:"
+	rustc --version              # rust compiler
+	cargo --version              # rust package manager
+	rustfmt --version            # rust code formatter
+	rustup --version             # rust toolchain manager
+	clippy-driver --version      # rust linter
+
+format:
+	cargo fmt --quiet
+
+lint:
+	cargo clippy --quiet
+
+test:
+	cargo test --quiet
+
+run:
+	cargo run
+
+release:
+	cargo build --release
+
+all: format lint test run

--- a/Module1-Rust-Data-Structures/exercises/top_words/src/main.rs
+++ b/Module1-Rust-Data-Structures/exercises/top_words/src/main.rs
@@ -1,0 +1,24 @@
+use std::collections::LinkedList;
+
+fn main() {
+    let mut word_list: LinkedList<(&str, usize)> = LinkedList::new();
+
+    // Example data
+    word_list.push_back(("hello", 5));
+    word_list.push_back(("world", 3));
+    word_list.push_back(("rust", 8));
+
+    // Convert LinkedList to Vec for sorting
+    let mut word_vec: Vec<_> = word_list.into_iter().collect();
+
+    // Sort the Vec
+    word_vec.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Convert Vec back to LinkedList (if needed)
+    let sorted_list: LinkedList<_> = word_vec.into_iter().collect();
+
+    // Print sorted list
+    for (word, count) in &sorted_list {
+        println!("{}: {}", word, count);
+    }
+}

--- a/Module1-Rust-Data-Structures/exercises/top_words/text.txt
+++ b/Module1-Rust-Data-Structures/exercises/top_words/text.txt
@@ -1,0 +1,1 @@
+Rust is a great programming language. Rust is fast, safe, and fun!

--- a/Module1-Rust-Data-Structures/exercises/word_freq/Cargo.toml
+++ b/Module1-Rust-Data-Structures/exercises/word_freq/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
-name = "word_freq"
+name = "top_words"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-std = "0.1.0"


### PR DESCRIPTION
1. add Rust project [top_words] rs for  Words Linked List
Creates a linked list of the most common words in a text file and sorts it alphabetically.
2. fix Cargo.toml